### PR TITLE
Add isDescribedBy.createdBy facet

### DIFF
--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -1053,7 +1053,7 @@ function edoweb_basic_list_entities(EntityFieldQuery $efq, $operations = array()
         if ('contentType' == $jsonld_property) {
           $efq->entityCondition('bundle', array($value));
         } else if ('createdBy' == $jsonld_property) {
-          $efq->entityCondition('uid', $value);
+          $efq->propertyCondition('uid', $value);
         } else {
           $field_name = _jsonld_key_to_field_name($jsonld_property);
           $efq->fieldCondition(

--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -1052,6 +1052,8 @@ function edoweb_basic_list_entities(EntityFieldQuery $efq, $operations = array()
         // Add facet to query
         if ('contentType' == $jsonld_property) {
           $efq->entityCondition('bundle', array($value));
+        } else if ('createdBy' == $jsonld_property) {
+          $efq->entityCondition('uid', $value);
         } else {
           $field_name = _jsonld_key_to_field_name($jsonld_property);
           $efq->fieldCondition(

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -461,7 +461,6 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
       $index
     );
     $query = $this->_efq_to_es($efq, $page);
-
     $http_response = $this->_http_post(
       $http_url, $query, 'application/json'
     );
@@ -563,7 +562,7 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
             $uids = array($uids);
           }
           $query['query']['filtered']['filter']['bool']['must'][]['terms']
-            ["creator"] = $uids;
+            ['isDescribedBy.createdBy'] = $uids;
           break;
       }
     }

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -623,6 +623,14 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
       = 'subject.@id';
     $query['facets']['issued']['terms']['field']
       = 'issued';
+
+    global $user;
+    if (in_array('edoweb_backend_admin', $user->roles)
+        || in_array('edoweb_backend_user', $user->roles)) {
+      $query['facets']['createdBy']['terms']['field']
+        = 'isDescribedBy.createdBy';
+    }
+
     return json_encode($query);
   }
 


### PR DESCRIPTION
Please add `isDescribedBy` and `createdBy` to the global context (edoweb-resources.json) of regal-api.