### PR TITLE
Also use fulltext_index for public queries

### DIFF
--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -485,7 +485,7 @@ function edoweb_info_page() {
     'monograph', 'journal', 'volume', 'issue', 'article', 'file', 'webpage', 'version'
   ));
   $content['resource_list'] = edoweb_basic_search_entities(
-    $query, TRUE, array(), TRUE, user_access('edit any edoweb_basic entity'), TRUE, 'compact'
+    $query, TRUE, array(), TRUE, user_access('edit any edoweb_basic entity'), TRUE, 'compact', TRUE
   );
 
   return $content;
@@ -567,7 +567,7 @@ function _edoweb_search($bundle_name = null, $field_name = null) {
 
 }
 
-function edoweb_basic_search_entities_form($form, &$form_state, $advanced, $search_count, $query) {
+function edoweb_basic_search_entities_form($form, &$form_state, $advanced, $search_count, $query, $fulltext_option = false) {
 
   $form['#method'] = 'get';
 
@@ -583,6 +583,7 @@ function edoweb_basic_search_entities_form($form, &$form_state, $advanced, $sear
         || 'op' == $key
         || "query[$search_count][type]" == urldecode($key)
         || "query[$search_count][user]" == urldecode($key)
+        || "query[$search_count][fulltext]" == urldecode($key)
         ) continue;
     $form['query']['url_params'][] = array(
       '#type' => 'hidden',
@@ -615,6 +616,14 @@ function edoweb_basic_search_entities_form($form, &$form_state, $advanced, $sear
     );
   }
 
+  if ($fulltext_option) {
+    $form['query'][$search_count]['fulltext'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Volltexte'),
+      '#default_value' => isset($query['fulltext']),
+    );
+  }
+
   $form['query'][$search_count]['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Search'),
@@ -635,7 +644,9 @@ function edoweb_basic_search_entities_form($form, &$form_state, $advanced, $sear
 }
 
 function edoweb_basic_search_entities(
-  EntityFieldQuery $efq, $advanced = FALSE, $operations = array(), $list_noterm = TRUE, $add_links = FALSE, $sortable = TRUE, $view_mode = 'default'
+  EntityFieldQuery $efq, $advanced = FALSE, $operations = array(),
+  $list_noterm = TRUE, $add_links = FALSE, $sortable = TRUE,
+  $view_mode = 'default', $fulltext_option = false
 ) {
   static $search_count = 0;
   if (array_key_exists('query', $_GET)
@@ -657,7 +668,7 @@ function edoweb_basic_search_entities(
 
   $content = array();
   $content['search'] = drupal_get_form(
-    'edoweb_basic_search_entities_form', $advanced, $search_count, $query
+    'edoweb_basic_search_entities_form', $advanced, $search_count, $query, $fulltext_option
   );
 
   unset($content['search']['form_build_id']);
@@ -700,6 +711,10 @@ function edoweb_basic_search_entities(
 
   if (@$term = $query['term']) {
     $efq->addMetaData('term', $term);
+  }
+
+  if (@$fulltext = $query['fulltext']) {
+    $efq->addTag('fulltext');
   }
 
   if ($term || $list_noterm) {

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -497,7 +497,7 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
   protected function _query_elasticsearch(EntityFieldQuery $efq, $page = 0) {
     $index = user_access('edit any edoweb_basic entity')
       ? variable_get('edoweb_api_namespace')
-      : 'public_' . variable_get('edoweb_api_namespace') . ',fulltext_index';
+      : 'public_' . variable_get('edoweb_api_namespace') . ',fulltext_edoweb';
     // Search resources
     $http_url = sprintf(
       '%s/search/%s/_search',

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -497,14 +497,19 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
   protected function _query_elasticsearch(EntityFieldQuery $efq, $page = 0) {
     $index = user_access('edit any edoweb_basic entity')
       ? variable_get('edoweb_api_namespace')
-      : 'public_' . variable_get('edoweb_api_namespace')
-        . ',fulltext_' . variable_get('edoweb_api_namespace');
+      : 'public_' . variable_get('edoweb_api_namespace');
+
+    if (isset($efq->tags['fulltext'])) {
+      $index .= ',fulltext_' . variable_get('edoweb_api_namespace');
+    }
+
     // Search resources
     $http_url = sprintf(
       '%s/search/%s/_search',
       $this->__edoweb_api_host,
       $index
     );
+
     $query = $this->_efq_to_es($efq, $page);
     $http_response = $this->_http_post(
       $http_url, $query, 'application/json'

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -497,7 +497,7 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
   protected function _query_elasticsearch(EntityFieldQuery $efq, $page = 0) {
     $index = user_access('edit any edoweb_basic entity')
       ? variable_get('edoweb_api_namespace')
-      : 'public_' . variable_get('edoweb_api_namespace');
+      : 'public_' . variable_get('edoweb_api_namespace') . ',fulltext_index';
     // Search resources
     $http_url = sprintf(
       '%s/search/%s/_search',

--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -497,7 +497,8 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
   protected function _query_elasticsearch(EntityFieldQuery $efq, $page = 0) {
     $index = user_access('edit any edoweb_basic entity')
       ? variable_get('edoweb_api_namespace')
-      : 'public_' . variable_get('edoweb_api_namespace') . ',fulltext_edoweb';
+      : 'public_' . variable_get('edoweb_api_namespace')
+        . ',fulltext_' . variable_get('edoweb_api_namespace');
     // Search resources
     $http_url = sprintf(
       '%s/search/%s/_search',


### PR DESCRIPTION
Warning: queries will fail completely if fulltext_index is missing (as on e.g. https://api.edoweb-test.hbz-nrw.de/search/public_edoweb,fulltext_index/_search)