### PR TITLE
Set compact view mode for child list

### DIFF
--- a/edoweb/edoweb.install
+++ b/edoweb/edoweb.install
@@ -2068,11 +2068,9 @@ function _edoweb_field_instance_defaults($field_name) {
     ),
     'field_edoweb_filesize' => array(
       'label' => $t('Größe (Byte)'),
-      'display' => array('compact' => array()),
     ),
     'field_edoweb_filetype' => array(
       'label' => $t('Dateityp'),
-      'display' => array('compact' => array()),
     ),
     'field_edoweb_datastream' => array(
       'label' => $t('Datei'),

--- a/edoweb/edoweb.js
+++ b/edoweb/edoweb.js
@@ -85,7 +85,7 @@
     /**
      * Function loads a tabular view for a list of linked entities
      */
-    entity_table: function(field_items, operations) {
+    entity_table: function(field_items, operations, view_mode = 'default') {
       field_items.each(function() {
         var container = $(this);
         var curies = [];
@@ -99,7 +99,7 @@
           container.siblings('table').remove();
           var throbber = $('<div class="ajax-progress"><div class="throbber">&nbsp;</div></div>')
           container.before(throbber);
-          Drupal.edoweb.entity_list('edoweb_basic', curies, columns).onload = function () {
+          Drupal.edoweb.entity_list('edoweb_basic', curies, columns, view_mode).onload = function () {
             if (this.status == 200) {
               var result_table = $(this.responseText).find('table');
               result_table.find('a[data-curie]').not('.resolved').not('.edoweb.download').each(function() {
@@ -144,10 +144,15 @@
     },
 
     /**
-     * Function returns an entities label.
+     * Function returns a list of entities.
      */
-    entity_list: function(entity_type, entity_curies, columns) {
-      return $.get(Drupal.settings.basePath + 'edoweb_entity_list/' + entity_type + '?' + $.param({'ids': entity_curies, 'columns': columns}));
+    entity_list: function(entity_type, entity_curies, columns, view_mode) {
+      return $.get(Drupal.settings.basePath
+        + 'edoweb_entity_list/'
+        + entity_type
+        + '/' + view_mode
+        + '?' + $.param({'ids': entity_curies, 'columns': columns})
+      );
     },
 
     /**

--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -3267,3 +3267,12 @@ function edoweb_update_7149() {
   user_role_grant_permissions($remote_role->rid, $permissions[$remote_role->name]);
 }
 
+/**
+ * Remove filesize and filetype from file compact view mode
+ */
+function edoweb_update_7150() {
+  $updated_instances = array(
+    'file' => array('field_edoweb_filesize', 'field_edoweb_filetype')
+  );
+  _update_edoweb_installed_instances($updated_instances);
+}

--- a/edoweb/edoweb_view.js
+++ b/edoweb/edoweb_view.js
@@ -26,7 +26,13 @@
 
       $('.edoweb.entity.default', context).each(function() {
         // Load entities into table
-        Drupal.edoweb.entity_table($(this).find('.field-type-edoweb-ld-reference .field-items'));
+        Drupal.edoweb.entity_table($(this)
+          .find('.field-type-edoweb-ld-reference:not(.field-name-field-edoweb-struct-child) .field-items')
+        );
+        Drupal.edoweb.entity_table($(this)
+          .find('.field-type-edoweb-ld-reference.field-name-field-edoweb-struct-child .field-items'),
+            null, 'compact'
+        );
       });
 
       // Process result listing tables

--- a/edoweb_field/edoweb_field.module
+++ b/edoweb_field/edoweb_field.module
@@ -64,7 +64,7 @@ function edoweb_field_menu() {
   );
   $items['edoweb_entity_list'] = array(
     'page callback' => 'edoweb_entity_list',
-    'page arguments' => array(1),
+    'page arguments' => array(1, 2),
     'access callback' => 'entity_js_access',
     'access arguments' => array(1, 'read'),
     'type' => MENU_CALLBACK,
@@ -91,12 +91,12 @@ function edoweb_entity_label($entity_type, $entity_id) {
 /**
  * List entities function for JavaScript callbacks.
  */
-function edoweb_entity_list($entity_type) {
+function edoweb_entity_list($entity_type, $view_mode) {
   $ids = isset($_GET['ids']) && !empty($_GET['ids']) ? $_GET['ids'] : array();
   $columns = isset($_GET['columns']) ? $_GET['columns'] : 'generic';
   $entities = edoweb_basic_load_multiple($ids);
   $header = edoweb_basic_table_header($columns);
-  $output = edoweb_basic_entity_table($header, $entities);
+  $output = edoweb_basic_entity_table($header, $entities, array(), null, $view_mode);
   die(drupal_render($output));
 }
 


### PR DESCRIPTION
Note that regardless of the child's type (file and others) the compact view mode is now
used as they are all in the same field.

Fixes EDOZWO 474, please clear cache