### PR TITLE
Set ES query string default operator to AND

### DIFF
--- a/edoweb_storage/EdowebAPIClient.inc
+++ b/edoweb_storage/EdowebAPIClient.inc
@@ -628,6 +628,8 @@ class EdowebAPIClient implements EdowebAPIClientInterface {
     if (array_key_exists('term', $efq->metaData)) {
       $query['query']['filtered']['query']['query_string']['query']
         = $efq->metaData['term'];
+      $query['query']['filtered']['query']['query_string']['default_operator']
+        = 'AND';
     }
 
     if (array_key_exists('bundle', $efq->entityConditions)) {


### PR DESCRIPTION
Please note that this does not influence queries to the lobid API, only to regal's elasticsearch.

Fixes EDOZWO-426, fixes EDOZWO-90