### PR TITLE
Add 'part' bundle

### DIFF
--- a/edoweb/edoweb.install
+++ b/edoweb/edoweb.install
@@ -1365,6 +1365,7 @@ function _edoweb_installed_instances() {
           'target_type' => 'edoweb_basic',
           'handler_settings' => array(
             'target_bundles' => array(
+              'part' => 'part',
               'file' => 'file',
             ),
           ),
@@ -1466,6 +1467,7 @@ function _edoweb_installed_instances() {
               'issue' => 'issue',
               'article' => 'article',
               'file' => 'file',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1513,6 +1515,7 @@ function _edoweb_installed_instances() {
               'issue' => 'issue',
               'article' => 'article',
               'file' => 'file',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1523,6 +1526,7 @@ function _edoweb_installed_instances() {
           'handler_settings' => array(
             'target_bundles' => array(
               'journal' => 'journal',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1546,6 +1550,7 @@ function _edoweb_installed_instances() {
             'target_bundles' => array(
               'article' => 'article',
               'file' => 'file',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1557,6 +1562,7 @@ function _edoweb_installed_instances() {
             'target_bundles' => array(
               'journal' => 'journal',
               'volume' => 'volume',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1587,6 +1593,7 @@ function _edoweb_installed_instances() {
           'handler_settings' => array(
             'target_bundles' => array(
               'file' => 'file',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1599,6 +1606,7 @@ function _edoweb_installed_instances() {
               'journal' => 'journal',
               'volume' => 'volume',
               'issue' => 'issue',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1627,6 +1635,7 @@ function _edoweb_installed_instances() {
               'issue' => 'issue',
               'article' => 'article',
               'webpage' => 'webpage',
+              'part' => 'part',
             ),
           ),
         ),
@@ -1928,6 +1937,43 @@ function _edoweb_installed_instances() {
           'handler_settings' => array(
             'target_bundles' => array(
               'collection' => 'collection',
+            ),
+          ),
+        ),
+      ),
+    ),
+
+    /*
+     * Field instances in part bundle
+     */
+    'part' => array(
+      'field_edoweb_title' => array(),
+      'field_edoweb_struct_child' => array(
+        'settings'    => array(
+          'target_type' => 'edoweb_basic',
+          'handler_settings' => array(
+            'target_bundles' => array(
+              'volume' => 'volume',
+              'issue' => 'issue',
+              'article' => 'article',
+              'file' => 'file',
+              'part' => 'part',
+            ),
+          ),
+        ),
+      ),
+      'field_edoweb_struct_parent' => array(
+        'settings'    => array(
+          'target_type' => 'edoweb_basic',
+          'handler_settings' => array(
+            'target_bundles' => array(
+              'monograph' => 'monograph',
+              'journal' => 'journal',
+              'volume' => 'volume',
+              'issue' => 'issue',
+              'article' => 'article',
+              'file' => 'file',
+              'part' => 'part',
             ),
           ),
         ),

--- a/edoweb/edoweb.install
+++ b/edoweb/edoweb.install
@@ -1972,7 +1972,6 @@ function _edoweb_installed_instances() {
               'volume' => 'volume',
               'issue' => 'issue',
               'article' => 'article',
-              'file' => 'file',
               'part' => 'part',
             ),
           ),

--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -192,6 +192,13 @@ function edoweb_entity_info() {
           'access arguments' => array('administer edoweb_basic entities'),
         ),
       ),
+      'part' => array(
+        'label' => t('Part'),
+        'admin' => array(
+          'path' => 'admin/structure/edoweb_basic/part/manage',
+          'access arguments' => array('administer edoweb_basic entities'),
+        ),
+      ),
       'person' => array(
         'label' => t('Person'),
         'namespace' => 'local',
@@ -811,6 +818,7 @@ function edoweb_basic_table_header($bundle_type = 'generic', $init_sort = false)
     case 'webpage':
     case 'version':
     case 'generic':
+    case 'part':
       $columns = array(
         array(
           'data' => t('HT-Nummer'),
@@ -2291,6 +2299,8 @@ function edoweb_rdf_types($bundle = null) {
     //FIXME: dummy RDF type for version
     'version' => array('lv:ArchivedWebPageVersion'),
     'generic' => array('dc:BibliographicResource'),
+    //FIXME: do we need an RDF type mapping for the 'part' bundle?
+    'part' => array('dc:BibliographicResource'),
     'authority_resource' => array('gnd:AuthorityResource'),
     'collection' => array(
       'bibo:Collection',
@@ -3704,3 +3714,40 @@ function edoweb_update_7155() {
   _update_edoweb_installed_instances($updated_instances);
   _update_rdf_mapping();
 }
+
+function edoweb_update_7156() {
+  module_load_install('edoweb');
+  $available_instances = _edoweb_installed_instances();
+  $updated_instances_fields = array(
+    'field_edoweb_struct_child',
+    'field_edoweb_struct_parent'
+  );
+  $updated_instances = array(
+    'part' => array_keys($available_instances['part']),
+    'monograph' => array(
+      'field_edoweb_struct_child',
+    ),
+    'journal' => array(
+      'field_edoweb_struct_child',
+    ),
+    'volume' => array(
+      'field_edoweb_struct_child',
+      'field_edoweb_struct_parent'
+    ),
+    'issue' => array(
+      'field_edoweb_struct_child',
+      'field_edoweb_struct_parent'
+    ),
+    'article' => array(
+      'field_edoweb_struct_child',
+      'field_edoweb_struct_parent'
+    ),
+    'file' => array(
+      'field_edoweb_struct_parent'
+    ),
+  );
+  _update_edoweb_installed_instances($updated_instances);
+  _update_rdf_mapping();
+  entity_info_cache_clear();
+}
+

--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -541,7 +541,7 @@ function edoweb_info_page() {
   $query->addTag('elasticsearch');
   $query->entityCondition('entity_type', 'edoweb_basic');
   $query->entityCondition('bundle', array(
-    'monograph', 'journal', 'volume', 'issue', 'article', 'file', 'webpage', 'version'
+    'monograph', 'journal', 'volume', 'issue', 'article', 'file', 'webpage', 'version', 'part'
   ));
   $content['resource_list'] = edoweb_basic_search_entities(
     $query, TRUE, array(), TRUE, user_access('edit any edoweb_basic entity'), TRUE, 'compact', TRUE
@@ -1401,7 +1401,7 @@ function edoweb_basic_view($entity, $view_mode = 'default') {
       }
       if ($has_inverse) {
         $inverse_query->entityCondition('bundle', array(
-          'monograph', 'journal', 'volume', 'issue', 'article', 'file'
+          'monograph', 'journal', 'volume', 'issue', 'article', 'file', 'part'
         ));
         $entity->content['related'] = edoweb_basic_search_entities(
           $inverse_query

--- a/edoweb/edoweb_tree.js
+++ b/edoweb/edoweb_tree.js
@@ -218,10 +218,16 @@
         var bundle_fields = Drupal.settings.edoweb.fields[$(this).children('a[data-bundle]').attr('data-bundle')];
         var target_bundles = [];
         if (bundle_fields && 'field_edoweb_struct_child' in bundle_fields) {
-          var target_bundles = Object.keys(bundle_fields
+          if (bundle_fields
             ['field_edoweb_struct_child']
             ['instance']['settings']
-            ['handler_settings']['target_bundles']);
+            ['handler_settings']['target_bundles'] != null
+          ) {
+            target_bundles = Object.keys(bundle_fields
+              ['field_edoweb_struct_child']
+              ['instance']['settings']
+              ['handler_settings']['target_bundles']);
+          }
         }
 
         // Possible insert positions are as a child of the current entry


### PR DESCRIPTION
Currently, 'part' can be a child of anything but 'file' (leaf node) and
can contain anything but 'monograph' and 'journal' (root nodes).

Please run update script.