### PR TITLE
EDOZWO-729

### DIFF
--- a/edoweb/edoweb.module
+++ b/edoweb/edoweb.module
@@ -2131,10 +2131,12 @@ function edoweb_basic_crawler_form($form, &$form_state, $entity) {
       'ignore' => t('Ignore'),
       'obey' => t('Obey'),
     ),
-    '#default_value' => @$conf['robotsPolicy'] == 'classic' ? 'obey' : @$conf['robotsPolicy'],
+    '#default_value' => @$conf['robotsPolicy'] == null ? 'obey' : @$conf['robotsPolicy'] == 'classic' ? 'obey' : @$conf['robotsPolicy'],
     '#required' => TRUE,
     '#weight' => 50,
   );
+  console_log('issetRobotsPolicy='.(@$conf['robotsPolicy']!==null));
+  console_log('robotsPolicy='.@$conf['robotsPolicy']);
 
   $form['crawlerSelection'] = array(
     '#type' => 'select',
@@ -2143,11 +2145,14 @@ function edoweb_basic_crawler_form($form, &$form_state, $entity) {
       'heritrix' => t('heritrix'),
       'wpull' => t('wpull'),
     ),
-    // '#default_value' => isset(@$conf['crawlerSelection']) ? @$conf['crawlerSelection'] : 'heritrix',
-    '#default_value' => @$conf['crawlerSelection'],
+    '#default_value' => @$conf['crawlerSelection'] == null ? 'heritrix' : @$conf['crawlerSelection'],
     '#required' => FALSE,
     '#weight' => 60,
   );
+  console_log('issetCrawlerSelection='.(@$conf['crawlerSelection']!==null));
+  console_log('crawlerSelection='.@$conf['crawlerSelection']);
+  console_log('issetDeepness='.(@$conf['deepness']!==null));
+  console_log('deepness='.@$conf['deepness']);
 
   if( @$conf['crawlerSelection'] == 'wpull' ) {
 


### PR DESCRIPTION
set default robots policy to 'obey'  
- it was undefined, null

The change had to be made in the frontend.
Once a webpage is created newly and one switches to the "Crawler setting" tab for the first time, no Object "Gatherconf" has been created yet. The frontend displays an empty $conf.
So far, no choice had been made by the frontend concerning the selection of a robots policy - and none of the buttons was displayed as "pressed". Upon "Save", the system returned with an error, as a state with no button pressed cannot be saved.
Now, the $conf object fields are compared against "null". If they are "null", a default value is chosen by the frontend.

This new feature has been successfully tested on edoweb-test.